### PR TITLE
feat(sparql): enhance results display with multiple view modes and improved UX

### DIFF
--- a/components/ontology/__tests__/header.test.tsx
+++ b/components/ontology/__tests__/header.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { OntologyHeader } from '../header'
+import { OntologyProvider } from '@/lib/ontology/context'
 
 // Mock dialog components to avoid testing their internal behavior.
 // We only care that they render trigger buttons.
@@ -15,9 +16,17 @@ jest.mock('../import-export-dialog', () => ({
   ImportExportDialog: () => <button>Import / Export</button>,
 }))
 
+jest.mock('../global-search', () => ({
+  GlobalSearch: () => <div>Global Search</div>,
+}))
+
 describe('OntologyHeader', () => {
+  const renderWithProvider = (ui: React.ReactElement) => {
+    return render(<OntologyProvider>{ui}</OntologyProvider>)
+  }
+
   it('renders the application title', () => {
-    render(<OntologyHeader />)
+    renderWithProvider(<OntologyHeader />)
 
     expect(screen.getByText('Protege')).toBeInTheDocument()
     expect(screen.getByText('TS')).toBeInTheDocument()
@@ -25,7 +34,7 @@ describe('OntologyHeader', () => {
   })
 
   it('renders all action buttons', () => {
-    render(<OntologyHeader />)
+    renderWithProvider(<OntologyHeader />)
 
     expect(screen.getByRole('button', { name: /new entity/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reasoner/i })).toBeInTheDocument()
@@ -34,7 +43,7 @@ describe('OntologyHeader', () => {
   })
 
   it('renders a semantic header element for accessibility', () => {
-    render(<OntologyHeader />)
+    renderWithProvider(<OntologyHeader />)
 
     expect(screen.getByRole('banner')).toBeInTheDocument()
   })
@@ -43,6 +52,6 @@ describe('OntologyHeader', () => {
     // This test intentionally does not simulate keyboard shortcuts
     // because OntologyHeader does not currently define any.
     // It acts as a guard against regressions when shortcuts are added later.
-    expect(() => render(<OntologyHeader />)).not.toThrow()
+    expect(() => renderWithProvider(<OntologyHeader />)).not.toThrow()
   })
 })

--- a/lib/ontology/context.tsx
+++ b/lib/ontology/context.tsx
@@ -44,9 +44,7 @@ type OntologyContextType = {
 const OntologyContext = createContext<OntologyContextType | undefined>(undefined)
 
 
-export function OntologyProvider({ children }: { children: React.ReactNode }):JSX.Element {
-
-export function OntologyProvider({ children }: { children: React.ReactNode }) {
+export function OntologyProvider({ children }: { children: React.ReactNode }): JSX.Element {
   /**
    * The full ontology object is stored as a single state value.
    * Internally, it contains Maps for fast lookup and mutation.
@@ -264,16 +262,13 @@ export function OntologyProvider({ children }: { children: React.ReactNode }) {
 }
 
 
-export function useOntology():OntologyContextType {
-
 /**
  * Consumer hook with a guard to ensure correct usage.
  *
  * Throwing here provides a fast, clear failure mode during development
  * instead of silently returning undefined behavior.
  */
-export function useOntology() {
-
+export function useOntology(): OntologyContextType {
   const context = useContext(OntologyContext)
   if (context === undefined) {
     throw new Error('useOntology must be used within an OntologyProvider')

--- a/lib/ontology/reasoner.ts
+++ b/lib/ontology/reasoner.ts
@@ -286,10 +286,6 @@ export class HermiTReasoner {
     const result = new Set<string>()
     const visited = new Set<string>()
 
-<
-    const traverse = (id: string):void => {
-      if (visited.has(id)) return
-
     const traverse = (id: string) => {
       if (visited.has(id)) {
         return

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/lang-json": "^6.0.2",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -702,6 +703,16 @@
         "@codemirror/view": "^6.17.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -2661,6 +2672,17 @@
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-json": "^6.0.2",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",


### PR DESCRIPTION
## Summary

This PR enhances the SPARQL query interface with multiple result view modes, improved user experience, and fixes several TypeScript compilation errors.

### ✨ New Features

#### 📊 Multiple View Modes for Results
- **Table View** - Traditional compact tabular display for quick data scanning
- **Card View** - Human-readable card-based layout with responsive grid (1-3 columns)
- **JSON View** - Syntax-highlighted JSON display using CodeMirror with:
  - Line numbers
  - Collapsible sections (fold gutter)
  - Read-only mode
  - Line wrapping
  - Dark theme

#### 🎯 Improved UX
- **Infinite Scroll**: Removed height constraints - all result data visible with natural scrolling
- **Sample Queries Repositioning**: Moved from bottom of page to inside Query Editor tab for better contextual access
- **View Mode Toggle**: Easy switching between view modes with visual feedback

### 🐛 Bug Fixes

#### TypeScript Compilation Errors Fixed
- **lib/ontology/context.tsx**:
  - Removed duplicate `OntologyProvider` function declaration
  - Removed duplicate `useOntology` function declaration
  
- **lib/ontology/reasoner.ts**:
  - Removed duplicate and broken `traverse` function declaration
  
- **components/ontology/__tests__/header.test.tsx**:
  - Added `OntologyProvider` wrapper for tests
  - Added mock for `GlobalSearch` component

### 📦 Dependencies

- Added `@codemirror/lang-json` (^6.0.2) for JSON syntax highlighting

### 🧪 Testing

- ✅ All 222 tests passing
- ✅ Build successful
- ✅ No breaking changes

### 📸 Screenshots

#### View Modes Toggle
Users can now switch between three different view modes using the toggle buttons in the results toolbar.

#### Card View
Results displayed as individual cards with clear field labels - perfect for detailed reading.

#### JSON View
Full JSON output with proper syntax highlighting and line numbers.

### 🎨 Technical Details

**Changes Made:**
1. Replaced `ScrollArea` with `overflow-auto` div for better infinite scrolling
2. Added CodeMirror integration with JSON language support
3. Implemented responsive grid layout for card view
4. Refactored results section to support conditional rendering based on view mode
5. Cleaned up duplicate code causing TypeScript compilation errors

**Files Changed:**
- `components/ontology/sparql-query.tsx` - Main feature implementation
- `components/ontology/__tests__/header.test.tsx` - Test fixes
- `lib/ontology/context.tsx` - Duplicate code removal
- `lib/ontology/reasoner.ts` - Duplicate code removal
- `package.json` - Added new dependency
- `package-lock.json` - Lockfile update
- `next-env.d.ts` - Auto-generated types update

### 🔄 Migration Guide

No migration needed - all changes are backward compatible. Existing functionality remains intact with new view modes added as enhancements.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances SPARQL results UX and resolves TypeScript issues.
> 
> - Adds result view modes with toolbar: `table`, `cards`, and `json` (CodeMirror with JSON syntax, read-only, wrapping) in `components/ontology/sparql-query.tsx`
> - Replaces constrained `ScrollArea` with `overflow-auto` containers for natural scrolling; keeps JSON download action
> - Moves "Sample Queries" into the `editor` tab and adds count badge on `results` tab
> - Test updates: wrap header tests with `OntologyProvider` and mock `GlobalSearch` in `components/ontology/__tests__/header.test.tsx`
> - TypeScript fixes: remove duplicate `OntologyProvider`/`useOntology` declarations in `lib/ontology/context.tsx`; clean up duplicate/broken `traverse` in `lib/ontology/reasoner.ts`
> - Types path tweak in `next-env.d.ts`
> - Dependency: add `@codemirror/lang-json`; lockfile updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56ec73c9512364a6c073f8695221472d622b6b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->