### PR TITLE
feat(stats): add last modified timestamp tracking

### DIFF
--- a/components/ontology/ontology-stats.tsx
+++ b/components/ontology/ontology-stats.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useOntology } from '@/lib/ontology/context'
 import { Box, Link2, User } from 'lucide-react'
@@ -8,9 +8,11 @@ import { useToast } from '@/hooks/use-toast'
 import { Toaster } from '@/components/ui/toaster'
 import { Button } from '../ui/button'
 import { useCopyToClipboard } from '@/hooks/copy-to-clipboard'
+import { formatRelativeTime, formatAbsoluteTime } from '@/lib/utils'
 
 export function OntologyStats() {
   const { ontology } = useOntology()
+  const [, setUpdateTrigger] = useState(0)
 
   const classCount = ontology?.classes.size ?? 0
   const propertyCount = ontology?.properties.size ?? 0
@@ -29,6 +31,15 @@ export function OntologyStats() {
       })
     }
   }, [ontology, classCount, propertyCount, individualCount])
+
+  // Update relative time display every 10 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setUpdateTrigger(prev => prev + 1)
+    }, 10000) // Update every 10 seconds
+
+    return () => clearInterval(interval)
+  }, [])
 
   if (!ontology) {
     return null
@@ -109,6 +120,17 @@ export function OntologyStats() {
             <div>
               <div className="text-muted-foreground">Version:</div>
               <div className="font-mono">{ontology.version}</div>
+            </div>
+          )}
+          {ontology.lastModified && (
+            <div>
+              <div className="text-muted-foreground">Last Modified:</div>
+              <div
+                className="cursor-default"
+                title={formatAbsoluteTime(ontology.lastModified)}
+              >
+                {formatRelativeTime(ontology.lastModified)}
+              </div>
             </div>
           )}
         </CardContent>

--- a/lib/__tests__/time-utils.test.ts
+++ b/lib/__tests__/time-utils.test.ts
@@ -1,0 +1,73 @@
+import { formatRelativeTime, formatAbsoluteTime } from '../utils'
+
+describe('Time Formatting Utilities', () => {
+  describe('formatRelativeTime', () => {
+    it('should return "just now" for very recent dates', () => {
+      const now = new Date()
+      const recent = new Date(now.getTime() - 5000) // 5 seconds ago
+      expect(formatRelativeTime(recent)).toBe('just now')
+    })
+
+    it('should return seconds for times less than a minute ago', () => {
+      const now = new Date()
+      const thirtySecondsAgo = new Date(now.getTime() - 30000)
+      expect(formatRelativeTime(thirtySecondsAgo)).toBe('30 seconds ago')
+    })
+
+    it('should return "1 minute ago" for exactly one minute', () => {
+      const now = new Date()
+      const oneMinuteAgo = new Date(now.getTime() - 60000)
+      expect(formatRelativeTime(oneMinuteAgo)).toBe('1 minute ago')
+    })
+
+    it('should return minutes for times less than an hour ago', () => {
+      const now = new Date()
+      const thirtyMinutesAgo = new Date(now.getTime() - 30 * 60000)
+      expect(formatRelativeTime(thirtyMinutesAgo)).toBe('30 minutes ago')
+    })
+
+    it('should return "1 hour ago" for exactly one hour', () => {
+      const now = new Date()
+      const oneHourAgo = new Date(now.getTime() - 60 * 60000)
+      expect(formatRelativeTime(oneHourAgo)).toBe('1 hour ago')
+    })
+
+    it('should return hours for times less than a day ago', () => {
+      const now = new Date()
+      const fiveHoursAgo = new Date(now.getTime() - 5 * 60 * 60000)
+      expect(formatRelativeTime(fiveHoursAgo)).toBe('5 hours ago')
+    })
+
+    it('should return "1 day ago" for exactly one day', () => {
+      const now = new Date()
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60000)
+      expect(formatRelativeTime(oneDayAgo)).toBe('1 day ago')
+    })
+
+    it('should return days for times more than a day ago', () => {
+      const now = new Date()
+      const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60000)
+      expect(formatRelativeTime(fiveDaysAgo)).toBe('5 days ago')
+    })
+  })
+
+  describe('formatAbsoluteTime', () => {
+    it('should format date with full details', () => {
+      const testDate = new Date('2024-01-15T14:30:45')
+      const formatted = formatAbsoluteTime(testDate)
+
+      // Check that it contains expected components
+      expect(formatted).toContain('2024')
+      expect(formatted).toContain('January')
+      expect(formatted).toContain('15')
+    })
+
+    it('should include time components', () => {
+      const testDate = new Date('2024-06-20T09:15:30')
+      const formatted = formatAbsoluteTime(testDate)
+
+      // Should contain hour and minute
+      expect(formatted).toMatch(/\d{1,2}:\d{2}:\d{2}/)
+    })
+  })
+})

--- a/lib/ontology/context.tsx
+++ b/lib/ontology/context.tsx
@@ -120,7 +120,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const classes = new Map(prev.classes)
       classes.set(owlClass.id, owlClass)
-      return { ...prev, classes }
+      return { ...prev, classes, lastModified: new Date() }
     })
   }, [])
 
@@ -131,7 +131,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const properties = new Map(prev.properties)
       properties.set(property.id, property)
-      return { ...prev, properties }
+      return { ...prev, properties, lastModified: new Date() }
     })
   }, [])
 
@@ -142,7 +142,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const individuals = new Map(prev.individuals)
       individuals.set(individual.id, individual)
-      return { ...prev, individuals }
+      return { ...prev, individuals, lastModified: new Date() }
     })
   }, [])
 
@@ -162,7 +162,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       if (existing) {
         classes.set(classId, { ...existing, ...updates })
       }
-      return { ...prev, classes }
+      return { ...prev, classes, lastModified: new Date() }
     })
   }, [])
 
@@ -176,7 +176,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       if (existing) {
         properties.set(propertyId, { ...existing, ...updates })
       }
-      return { ...prev, properties }
+      return { ...prev, properties, lastModified: new Date() }
     })
   }, [])
 
@@ -194,7 +194,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const classes = new Map(prev.classes)
       classes.delete(classId)
-      return { ...prev, classes }
+      return { ...prev, classes, lastModified: new Date() }
     })
   }, [])
 
@@ -205,7 +205,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const properties = new Map(prev.properties)
       properties.delete(propertyId)
-      return { ...prev, properties }
+      return { ...prev, properties, lastModified: new Date() }
     })
   }, [])
 
@@ -219,7 +219,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       if (existing) {
         individuals.set(individualId, { ...existing, ...updates })
       }
-      return { ...prev, individuals }
+      return { ...prev, individuals, lastModified: new Date() }
     })
   }, [])
 
@@ -230,7 +230,7 @@ export function OntologyProvider({ children }: { children: React.ReactNode }): J
       }
       const individuals = new Map(prev.individuals)
       individuals.delete(individualId)
-      return { ...prev, individuals }
+      return { ...prev, individuals, lastModified: new Date() }
     })
   }, [])
 

--- a/lib/ontology/serializers.tsx
+++ b/lib/ontology/serializers.tsx
@@ -711,6 +711,7 @@ export function parseOWLXML(content: string): Ontology {
     properties,
     individuals,
     annotations: [],
+    lastModified: new Date(),
   }
 }
 
@@ -833,6 +834,7 @@ export function parseTurtle(content: string): Ontology {
     properties,
     individuals,
     annotations: [],
+    lastModified: new Date(),
   }
 }
 
@@ -991,6 +993,7 @@ export function parseJSONLD(content: string): Ontology {
     properties,
     individuals,
     annotations: [],
+    lastModified: new Date(),
   }
 }
 

--- a/lib/ontology/types.ts
+++ b/lib/ontology/types.ts
@@ -67,6 +67,7 @@ export type Ontology = {
   properties: Map<string, OntologyProperty>
   individuals: Map<string, Individual>
   annotations: Annotation[]
+  lastModified?: Date
 }
 
 export type OntologyStats = {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,38 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Formats a date as relative time (e.g., "2 minutes ago", "just now")
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  const diffMin = Math.floor(diffSec / 60)
+  const diffHour = Math.floor(diffMin / 60)
+  const diffDay = Math.floor(diffHour / 24)
+
+  if (diffSec < 10) return 'just now'
+  if (diffSec < 60) return `${diffSec} seconds ago`
+  if (diffMin === 1) return '1 minute ago'
+  if (diffMin < 60) return `${diffMin} minutes ago`
+  if (diffHour === 1) return '1 hour ago'
+  if (diffHour < 24) return `${diffHour} hours ago`
+  if (diffDay === 1) return '1 day ago'
+  return `${diffDay} days ago`
+}
+
+/**
+ * Formats a date as absolute time for tooltips
+ */
+export function formatAbsoluteTime(date: Date): string {
+  return date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}


### PR DESCRIPTION
## Description
Track and display when the ontology was last modified in the OntologyStats component. Shows relative time (e.g., "2 minutes ago") with tooltip showing absolute time.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
Closes #80

## Testing
- [x] Added unit tests (10 new tests for time utilities)
- [x] Manual testing completed
- [x] All 224 tests passing

## Implementation Details
- Added `lastModified?: Date` field to Ontology type
- Updated all 9 CRUD operations to set timestamp
- Created `formatRelativeTime()` and `formatAbsoluteTime()` utilities
- Integrated display into existing Ontology Info card (no scrollbar)
- Real-time updates every 10 seconds

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Tests pass locally (224/224)
- [x] No new warnings
- [x] TypeScript strict mode compliant