### PR TITLE
docs: add CONTRIBUTING.md with first-PR walkthrough and file map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,186 @@
-# Contributing to Modern Ontology Editor
+# Contributing to ProtegeDesk
 
-Thank you for your interest in contributing to Modern Ontology Editor! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to ProtegeDesk! This document provides guidelines and instructions for contributing.
 
-## 📋 Table of Contents
+## Table of Contents
 
+- [Welcome](#welcome)
+- [File Map](#file-map)
+- [Your First PR](#your-first-pr)
 - [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
-- [Development Workflow](#development-workflow)
-- [Coding Standards](#coding-standards)
+- [Code Style](#code-style)
+- [Commit Messages](#commit-messages)
 - [Testing Guidelines](#testing-guidelines)
 - [Pull Request Process](#pull-request-process)
+- [Good First Issues](#good-first-issues)
 - [Issue Guidelines](#issue-guidelines)
-- [Community](#community)
+
+---
+
+## Welcome
+
+ProtegeDesk is a next-generation, web-based ontology engineering platform built with Next.js, React, TypeScript, and Tailwind CSS. Whether you are fixing a typo, adding a test, or building a new feature, we are glad to have you.
+
+If you have never contributed to an open-source project before, start with the **[Your First PR](#your-first-pr)** section below. It walks you through every step, from forking the repo to opening a pull request.
+
+---
+
+## File Map
+
+Understanding where things live makes contributing much easier. Below is a map of the key directories and files in this repository.
+
+### Top-level layout
+
+```
+ProtegeDesk/
+├── app/                     # Next.js App Router pages and layout
+│   ├── layout.tsx           # Root layout (providers, theme, fonts)
+│   ├── page.tsx             # Home page (entry point)
+│   └── globals.css          # Global CSS / Tailwind base styles
+├── components/              # React components
+│   ├── ontology/            # Domain-specific UI for the ontology editor
+│   └── ui/                  # Shadcn/ui primitive components (Button, Dialog, etc.)
+├── lib/                     # Non-UI logic and domain code
+│   ├── ontology/            # Core ontology engine (reasoner, serializers, search, etc.)
+│   ├── constants.ts         # Shared constants (no magic numbers elsewhere)
+│   ├── graph-utils.ts       # Graph layout helpers
+│   └── utils.ts             # General-purpose utilities (cn helper, etc.)
+├── hooks/                   # Shared custom React hooks
+│   ├── copy-to-clipboard.ts
+│   └── use-toast.ts
+├── __tests__/               # Integration / fixture tests (e.g. sample OWL files)
+├── docs/                    # Project documentation
+│   ├── SRS.md               # Software Requirements Specification
+│   ├── ROADMAP.md           # Feature roadmap
+│   ├── TESTING.md           # Testing strategy details
+│   ├── ENVIRONMENT.md       # Environment configuration
+│   └── SECURITY.md          # Security policy
+├── wiki/                    # GitHub wiki source files
+├── styles/                  # Additional global CSS
+├── public/                  # Static assets (icons, sample ontologies, logos)
+├── jest.config.ts           # Jest configuration
+├── eslint.config.mjs        # ESLint flat config
+├── .prettierrc              # Prettier formatting rules
+├── tsconfig.json            # TypeScript configuration
+├── next.config.mjs          # Next.js configuration
+└── package.json             # Dependencies and scripts
+```
+
+### Key directories in detail
+
+| Directory | What goes here | Example files |
+|---|---|---|
+| `app/` | Next.js App Router entry points and layouts. Keep this thin — logic lives in `lib/` and `components/`. | `layout.tsx`, `page.tsx` |
+| `components/ontology/` | All ontology-editor-specific UI components. Each file is one concern (class tree, graph view, property details, etc.). | `class-tree.tsx`, `graph-view.tsx`, `reasoner-dialog.tsx` |
+| `components/ui/` | Auto-generated Shadcn/ui primitives. **Do not edit these by hand** — re-generate with the Shadcn CLI if you need changes. | `button.tsx`, `dialog.tsx`, `tabs.tsx` |
+| `lib/ontology/` | Core domain logic with no UI dependencies: reasoner, serializers, search, SPARQL, validation, sample-data generation. | `reasoner.ts`, `serializers.tsx`, `search.ts` |
+| `lib/ontology/__tests__/` | Unit tests for the ontology engine. | `reasoner.test.ts`, `serializers.test.ts` |
+| `components/ontology/__tests__/` | Component tests for ontology UI. | `header.test.tsx`, `new-entity-dialog.test.tsx` |
+| `hooks/` | Reusable React hooks shared across components. | `copy-to-clipboard.ts`, `use-toast.ts` |
+| `__tests__/` | Test fixtures (e.g. `.owl` sample files). | `pizza.owl`, `pizza-with-individuals.owl` |
+| `public/` | Static assets served as-is. | `sample-ontology.owl`, icons |
+| `docs/` | Long-form documentation. | `SRS.md`, `ROADMAP.md`, `TESTING.md` |
+
+---
+
+## Your First PR
+
+This section is a step-by-step walkthrough for making your first pull request to ProtegeDesk. No prior experience with the codebase is assumed.
+
+### 1. Fork the repository
+
+1. Go to [https://github.com/aadorian/ProtegeDesk](https://github.com/aadorian/ProtegeDesk)
+2. Click the **Fork** button in the top-right corner
+3. Create the fork under your own GitHub account
+
+### 2. Clone your fork locally
+
+```bash
+git clone https://github.com/YOUR_USERNAME/ProtegeDesk.git
+cd ProtegeDesk
+
+# Add the upstream remote so you can keep your fork in sync
+git remote add upstream https://github.com/aadorian/ProtegeDesk.git
+```
+
+### 3. Install dependencies
+
+```bash
+npm ci
+```
+
+> Use `npm ci` (not `npm install`) for a clean, reproducible install from the lockfile.
+
+### 4. Create a branch
+
+Use the branch prefixes described in [Commit Messages](#commit-messages) below:
+
+```bash
+git checkout -b docs/your-topic          # for documentation changes
+git checkout -b fix/short-description     # for bug fixes
+git checkout -b feature/short-description # for new features
+```
+
+### 5. Make your changes
+
+- Edit the relevant files (see the [File Map](#file-map) above if you are unsure where to look).
+- Follow the [Code Style](#code-style) guidelines.
+- Add or update tests if your change affects logic or UI behavior.
+
+### 6. Run the checks
+
+Before committing, always run the full validation suite:
+
+```bash
+npm run validate
+```
+
+This single command runs **all** of the following:
+
+| Check | What it does |
+|---|---|
+| `npm run type-check` | TypeScript strict type checking (`tsc --noEmit`) |
+| `npm run lint` | ESLint with React, hooks, a11y, and import rules |
+| `npm run format:check` | Prettier formatting verification |
+| `npm test` | Jest unit and component tests |
+
+If any check fails, fix the issue before proceeding. Common fixes:
+
+```bash
+npm run lint:fix    # auto-fix most ESLint issues
+npm run format      # auto-format code with Prettier
+```
+
+### 7. Commit your changes
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). See [Commit Messages](#commit-messages) for the full convention. Example:
+
+```bash
+git add .
+git commit -m "docs: add first-PR walkthrough to CONTRIBUTING.md"
+```
+
+### 8. Push and open a Pull Request
+
+```bash
+git push origin docs/your-topic
+```
+
+1. Go to your fork on GitHub — you will see a **"Compare & pull request"** prompt.
+2. Click it, fill in the PR template, and link the related issue (e.g. `Closes #221`).
+3. Wait for CI checks to pass and a maintainer to review.
+
+### 9. Keep your fork up to date
+
+While waiting for review, or before starting new work:
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
 
 ---
 
@@ -50,7 +218,7 @@ Violations can be reported to [conduct@example.com]. All complaints will be revi
 
 ---
 
-## Getting Started
+## Development Setup
 
 ### Prerequisites
 
@@ -59,99 +227,78 @@ Violations can be reported to [conduct@example.com]. All complaints will be revi
 - **Code Editor** (VS Code recommended)
 - **Modern Browser** for testing
 
-### First-Time Contributors
-
-Looking for a good first issue? Check out:
-
-- [good-first-issue](https://github.com/aadorian/ProtegeDesk/issues?q=is%3Aissue%20state%3Aopen%20label%3Agood-first-issue) label
-- [help-wanted](https://github.com/aadorian/ProtegeDesk/issues?q=is%3Aissue%20state%3Aopen%20label%3Ahelp-wanted) label
-
----
-
-## Development Setup
-
-### 1. Fork and Clone
+### Quick start
 
 ```bash
-# Fork the repository on GitHub
-# Then clone your fork
-
-git clone https://github.com/YOUR_USERNAME/modern-ontology-editor.git
-cd modern-ontology-editor
-
-# Add upstream remote
-git remote add upstream https://github.com/original/modern-ontology-editor.git
+git clone https://github.com/YOUR_USERNAME/ProtegeDesk.git
+cd ProtegeDesk
+npm ci
+npm run dev          # http://localhost:3000
 ```
 
-### 2. Install Dependencies
+### Verify everything works
 
 ```bash
-npm install
-```
-
-### 3. Set Up Environment
-
-```bash
-# Copy environment template
-cp .env.example .env.local
-
-# Edit .env.local with your configuration
-# For AI features, add your API keys:
-# OPENAI_API_KEY=your_key_here
-# ANTHROPIC_API_KEY=your_key_here
-```
-
-### 4. Run Development Server
-
-```bash
-npm run dev
-# Open http://localhost:3000
-```
-
-### 5. Verify Setup
-
-```bash
-# Run all checks
 npm run validate
-
-# This runs:
-# - TypeScript type checking
-# - ESLint
-# - Tests
 ```
 
 ---
 
-## Development Workflow
+## Code Style
 
-### Branch Strategy
+### TypeScript
 
-We use a simplified Git Flow:
+- **Always use TypeScript** — no plain `.js` or `.jsx` files.
+- **Strict mode** is enabled in `tsconfig.json`; respect it.
+- **Avoid `any`** — use `unknown` if the type is genuinely unknown.
+- **Use `interface`** for object shapes, `type` for unions and primitives.
+- **No `I` prefix** on interfaces (e.g. `OntologyClass`, not `IOntologyClass`).
 
-- `main` - Production-ready code
-- `develop` - Integration branch for features
-- `feature/*` - New features
-- `fix/*` - Bug fixes
-- `docs/*` - Documentation updates
-- `refactor/*` - Code refactoring
+### React
 
-### Creating a Feature Branch
+- **Functional components with hooks** only — no class components.
+- **Define a props type** above every component.
+- **Destructure props** in the function parameter.
+- **Use `React.memo`** for expensive render components.
+- **Put reusable logic** in `hooks/` or `lib/`.
+
+### Naming
+
+| Kind | Convention | Example |
+|---|---|---|
+| Component files | `PascalCase.tsx` | `class-tree.tsx` (kebab is also used in this repo) |
+| Utility / hook files | `camelCase.ts` | `graph-utils.ts`, `use-toast.ts` |
+| Components | `PascalCase` | `ClassTreeNode` |
+| Functions | `camelCase` | `selectClass` |
+| Constants | `UPPER_SNAKE_CASE` | `TREE_INDENT_PX` |
+| Types / Interfaces | `PascalCase` | `OntologyContextType` |
+
+### Formatting
+
+We use **ESLint 9** (flat config) and **Prettier**. Key rules from `.prettierrc`:
+
+- **No semicolons** (`"semi": false`)
+- **Single quotes** for JS/TS strings
+- **2-space** indentation
+- **Trailing commas** (ES5)
+- **Max line width**: 100 characters
+- **Arrow parens**: avoid (`x => x`, not `(x) => x`)
+
+Run the formatters:
 
 ```bash
-# Update your fork
-git checkout develop
-git pull upstream develop
-
-# Create feature branch
-git checkout -b feature/your-feature-name
-
-# Make changes, commit, push
-git add .
-git commit -m "feat: add your feature"
-git push origin feature/your-feature-name
+npm run format      # auto-format
+npm run lint:fix    # auto-fix lint issues
+npm run validate    # run all checks
 ```
 
-### Commit Message Convention
+### Constants
+
+All numeric or string constants must live in `lib/constants.ts`. ESLint will warn on "magic numbers" found outside that file.
+
+---
+
+## Commit Messages
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
@@ -163,17 +310,19 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 <footer>
 ```
 
-**Types**:
+### Types
 
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
+| Type | When to use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, whitespace (no logic change) |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `chore` | Build, tooling, or maintenance |
 
-**Examples**:
+### Examples
 
 ```bash
 feat(editor): add autocomplete for object properties
@@ -194,263 +343,50 @@ Added cycle detection before layout.
 Fixes #456
 ```
 
-### Keeping Your Fork Updated
+### Branch prefixes
 
-```bash
-# Fetch upstream changes
-git fetch upstream
+Use the same type as a prefix for your branch name:
 
-# Merge into your branch
-git checkout develop
-git merge upstream/develop
-
-# Update your fork on GitHub
-git push origin develop
-```
-
----
-
-## Coding Standards
-
-### TypeScript
-
-- **Always use TypeScript** - No plain JavaScript files
-- **Strict mode enabled** - Follow tsconfig.json settings
-- **Type everything** - Avoid `any`, use `unknown` if needed
-- **Use interfaces** for object shapes
-- **Use types** for unions and primitives
-
-**Good**:
-
-```typescript
-interface OntologyClass {
-  id: string
-  label: string
-  parent?: string
-  annotations: Record<string, string>
-}
-
-function createClass(data: OntologyClass): void {
-  // Implementation
-}
-```
-
-**Bad**:
-
-```typescript
-function createClass(data: any) {
-  // ❌ No any
-  // Implementation
-}
-```
-
-### React
-
-- **Functional components** with hooks
-- **Props interfaces** always defined
-- **Destructure props** in parameter list
-- **Use React.memo** for expensive components
-- **Custom hooks** for reusable logic
-
-**Good**:
-
-```typescript
-interface ClassNodeProps {
-  id: string;
-  label: string;
-  onSelect: (id: string) => void;
-}
-
-const ClassNode: React.FC<ClassNodeProps> = ({
-  id,
-  label,
-  onSelect
-}) => {
-  const handleClick = useCallback(() => {
-    onSelect(id);
-  }, [id, onSelect]);
-
-  return (
-    <div onClick={handleClick}>
-      {label}
-    </div>
-  );
-};
-
-export default React.memo(ClassNode);
-```
-
-### File Organization
-
-```
-src/
-├── app/                    # Next.js app directory
-│   ├── api/               # API routes
-│   └── (routes)/          # Page routes
-├── components/            # React components
-│   ├── ui/               # Base UI components (Shadcn)
-│   ├── Editor/           # Editor-specific components
-│   ├── Graph/            # Graph visualization components
-│   └── ...
-├── lib/                   # Library code
-│   ├── ontology/         # Ontology domain logic
-│   └── utils/            # Utility functions
-├── services/              # External service integrations
-│   ├── ai/               # AI service
-│   ├── parser/           # Parsing service
-│   └── reasoning/        # Reasoning service
-├── hooks/                 # Custom React hooks
-├── stores/                # Zustand stores
-├── types/                 # TypeScript type definitions
-└── utils/                 # Utility functions
-```
-
-### Naming Conventions
-
-- **Files**: `PascalCase.tsx` for components, `camelCase.ts` for utilities
-- **Components**: `PascalCase`
-- **Functions**: `camelCase`
-- **Constants**: `UPPER_SNAKE_CASE`
-- **Interfaces**: `PascalCase` (no `I` prefix)
-- **Types**: `PascalCase` (often with `Type` suffix)
-
-### Code Style
-
-We use **ESLint** and **Prettier**:
-
-```bash
-# Format code
-npm run format
-
-# Lint code
-npm run lint
-
-# Auto-fix issues
-npm run lint:fix
-```
-
-**Key rules**:
-
-- **2 spaces** for indentation
-- **Single quotes** for strings
-- **Semicolons** required
-- **Trailing commas** in multiline
-- **Max line length**: 100 characters
-- **Constants in one file**: No magic numbers outside of lib/constants.ts
+- `feature/short-description`
+- `fix/short-description`
+- `docs/short-description`
+- `refactor/short-description`
+- `test/short-description`
 
 ---
 
 ## Testing Guidelines
 
-### Test Requirements
+We use **Jest** with **React Testing Library** and **ts-jest**. All new features and bug fixes must include tests.
 
-All new features and bug fixes must include tests:
-
-- **Unit tests** for utilities and services
-- **Component tests** for React components
-- **Integration tests** for workflows
-- **E2E tests** for critical user journeys
-
-### Running Tests
+### Running tests
 
 ```bash
-# Run all tests
-npm test
-
-# Run tests in watch mode
-npm run test:watch
-
-# Run specific test file
-npm test ClassNode.test.tsx
-
-# Run E2E tests
-npm run test:e2e
-
-# Generate coverage report
-npm run test:coverage
+npm test              # run all tests
+npm run test:watch    # watch mode
+npm run test:coverage # with coverage report
+npm run test:ci       # CI-optimized run
 ```
 
-### Writing Unit Tests
+### Where to put tests
+
+| Code under test | Test location |
+|---|---|
+| `lib/ontology/*.ts` | `lib/ontology/__tests__/*.test.ts` |
+| `components/ontology/*.tsx` | `components/ontology/__tests__/*.test.tsx` |
+| `lib/utils.ts`, `hooks/*` | `lib/__tests__/*.test.ts` |
+| Fixtures (`.owl` files) | `__tests__/` |
+
+### Writing a test
 
 ```typescript
-// src/lib/ontology/OWLClass.test.ts
-import { describe, it, expect } from 'vitest'
-import { OWLClass } from './OWLClass'
+// lib/ontology/__tests__/my-module.test.ts
+import { myFunction } from '../my-module'
 
-describe('OWLClass', () => {
-  it('should create a class with valid IRI', () => {
-    const cls = new OWLClass('http://example.org#Person')
-    expect(cls.iri).toBe('http://example.org#Person')
+describe('myFunction', () => {
+  it('should handle normal input', () => {
+    expect(myFunction('input')).toBe('expected')
   })
-
-  it('should extract label from IRI', () => {
-    const cls = new OWLClass('http://example.org#Person')
-    expect(cls.getLabel()).toBe('Person')
-  })
-
-  it('should throw error for invalid IRI', () => {
-    expect(() => new OWLClass('invalid')).toThrow()
-  })
-})
-```
-
-### Writing Component Tests
-
-```typescript
-// src/components/ClassNode/ClassNode.test.tsx
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import ClassNode from './ClassNode';
-
-describe('ClassNode', () => {
-  it('renders class label', () => {
-    render(
-      <ClassNode
-        id="1"
-        label="Person"
-        onSelect={() => {}}
-      />
-    );
-    expect(screen.getByText('Person')).toBeInTheDocument();
-  });
-
-  it('calls onSelect when clicked', () => {
-    const handleSelect = vi.fn();
-    render(
-      <ClassNode
-        id="1"
-        label="Person"
-        onSelect={handleSelect}
-      />
-    );
-
-    fireEvent.click(screen.getByText('Person'));
-    expect(handleSelect).toHaveBeenCalledWith('1');
-  });
-});
-```
-
-### Writing E2E Tests
-
-```typescript
-// tests/e2e/ontology-creation.spec.ts
-import { test, expect } from '@playwright/test'
-
-test('user can create a new ontology', async ({ page }) => {
-  await page.goto('http://localhost:3000')
-
-  // Click New Ontology
-  await page.click('text=New Ontology')
-
-  // Fill in form
-  await page.fill('input[name="name"]', 'TestOntology')
-  await page.fill('input[name="iri"]', 'http://test.org/ontology#')
-
-  // Submit
-  await page.click('text=Create')
-
-  // Verify ontology created
-  await expect(page.locator('text=TestOntology')).toBeVisible()
 })
 ```
 
@@ -458,223 +394,84 @@ test('user can create a new ontology', async ({ page }) => {
 
 ## Pull Request Process
 
-### Before Submitting
+### Before submitting
 
-1. **Update your branch** with latest develop
-2. **Run all tests** - `npm test`
-3. **Run linting** - `npm run lint`
-4. **Run type checking** - `npm run type-check`
-5. **Update documentation** if needed
-6. **Add tests** for new features
+1. **Run `npm run validate`** — all checks must pass.
+2. **Add or update tests** for any changed logic or UI.
+3. **Update documentation** if your change affects user-facing behavior.
 
-### Submitting PR
+### Submitting a PR
 
-1. **Push your branch** to your fork
-2. **Open Pull Request** on GitHub
-3. **Fill out PR template** completely
-4. **Link related issues** using keywords (Closes #123)
-5. **Request review** from maintainers
+1. Push your branch to your fork.
+2. Open a Pull Request against the `main` branch of `aadorian/ProtegeDesk`.
+3. Fill out the PR template completely.
+4. Link the related issue using `Closes #<number>` or `Fixes #<number>`.
+5. Request review from a maintainer if appropriate.
 
-### PR Template
+### Review process
 
-```markdown
-## Description
+1. **Automated CI checks** must pass.
+2. **At least one maintainer** reviews and approves.
+3. Address any requested changes.
+4. Maintainer merges the PR.
 
-Brief description of changes
+### After merge
 
-## Type of Change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-
-## Related Issues
-
-Closes #123
-
-## Testing
-
-- [ ] Added unit tests
-- [ ] Added integration tests
-- [ ] Manual testing completed
-
-## Checklist
-
-- [ ] Code follows style guidelines
-- [ ] Self-review completed
-- [ ] Documentation updated
-- [ ] No new warnings
-- [ ] Tests pass locally
-```
-
-### Review Process
-
-1. **Automated checks** must pass (CI/CD)
-2. **Code review** by at least one maintainer
-3. **Changes requested** - address feedback
-4. **Approval** - maintainer approves PR
-5. **Merge** - maintainer merges to develop
-
-### After Merge
-
-1. **Delete your branch** (GitHub will prompt)
-2. **Update your fork**:
+1. Delete your branch (GitHub will prompt you).
+2. Sync your fork:
 
 ```bash
-git checkout develop
-git pull upstream develop
-git push origin develop
+git checkout main
+git pull upstream main
+git push origin main
 ```
+
+---
+
+## Good First Issues
+
+Looking for a place to start? These open issues are great for first-time contributors:
+
+| Issue | Title |
+|---|---|
+| [#221](https://github.com/aadorian/ProtegeDesk/issues/221) | Add CONTRIBUTING first-PR walkthrough with file map |
+| [#220](https://github.com/aadorian/ProtegeDesk/issues/220) | Add aria-live region for reasoner and import status messages |
+| [#219](https://github.com/aadorian/ProtegeDesk/issues/219) | Add component tests for CollapsibleCard |
+| [#218](https://github.com/aadorian/ProtegeDesk/issues/218) | Add component tests for ReasonerDialog |
+| [#212](https://github.com/aadorian/ProtegeDesk/issues/212) | Add component tests for ImportExportDialog |
+
+You can also browse the full list with the [`good-first-issue`](https://github.com/aadorian/ProtegeDesk/issues?q=is%3Aissue+state%3Aopen+label%3Agood-first-issue) and [`help-wanted`](https://github.com/aadorian/ProtegeDesk/issues?q=is%3Aissue+state%3Aopen+label%3Ahelp-wanted) labels.
 
 ---
 
 ## Issue Guidelines
 
-### Before Creating an Issue
+### Before creating an issue
 
-1. **Search existing issues** - avoid duplicates
-2. **Check documentation** - may already be answered
-3. **Verify version** - ensure you're using latest
+1. **Search existing issues** to avoid duplicates.
+2. **Check the documentation** in `docs/` and the wiki — the answer may already exist.
+3. **Verify you are on the latest version** of the `main` branch.
 
-### Bug Reports
+### Bug reports
 
-Use the [bug report template](https://github.com/yourusername/modern-ontology-editor/issues/new?template=bug_report.md)
-
-**Include**:
+Use the [bug report template](https://github.com/aadorian/ProtegeDesk/issues/new?template=bug_report.md). Include:
 
 - Clear description of the bug
 - Steps to reproduce
-- Expected behavior
-- Actual behavior
+- Expected behavior vs. actual behavior
 - Screenshots (if applicable)
 - Browser and OS
 - Console errors
 
-### Feature Requests
+### Feature requests
 
-Use the [feature request template](https://github.com/yourusername/modern-ontology-editor/issues/new?template=feature_request.md)
+Use the [feature request template](https://github.com/aadorian/ProtegeDesk/issues/new?template=feature_request.md). Include:
 
-**Include**:
-
-- Clear description of feature
+- Clear description of the feature
 - Use case / motivation
 - Proposed solution
 - Alternatives considered
-- Additional context
-
-### Questions
-
-For questions, use:
-
-- [GitHub Discussions](https://github.com/yourusername/modern-ontology-editor/discussions)
-- [Discord/Slack](link) for real-time chat
-- Stack Overflow with tag `modern-ontology-editor`
 
 ---
 
-## Community
-
-### Communication Channels
-
-- **GitHub Issues**: Bug reports, feature requests
-- **GitHub Discussions**: Questions, ideas, show & tell
-- **Discord/Slack**: Real-time chat with community
-- **Twitter**: [@ontology_editor](https://twitter.com/ontology_editor)
-
-### Getting Help
-
-- **Documentation**: Start with [docs/](docs/)
-- **FAQ**: Check [docs/faq.md](docs/faq.md)
-- **Discussions**: Ask in GitHub Discussions
-- **Chat**: Join Discord/Slack for quick questions
-
-### Recognition
-
-Contributors are recognized in:
-
-- [CONTRIBUTORS.md](CONTRIBUTORS.md) file
-- Release notes for significant contributions
-- Annual contributor highlights
-
----
-
-## Development Tips
-
-### Recommended VS Code Extensions
-
-```json
-{
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "bradlc.vscode-tailwindcss",
-    "streetsidesoftware.code-spell-checker",
-    "eamodio.gitlens",
-    "ms-playwright.playwright"
-  ]
-}
-```
-
-### Debugging
-
-```typescript
-// Enable debug logging
-localStorage.setItem('debug', 'moe:*')
-
-// In code
-import debug from 'debug'
-const log = debug('moe:component:ClassTree')
-log('Rendering tree with %d nodes', nodeCount)
-```
-
-### Performance Profiling
-
-```typescript
-// React DevTools Profiler
-import { Profiler } from 'react';
-
-<Profiler id="ClassTree" onRender={logRenderTime}>
-  <ClassTree />
-</Profiler>
-```
-
----
-
-## Release Process
-
-### Versioning
-
-We use [Semantic Versioning](https://semver.org/):
-
-- **MAJOR**: Breaking changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes
-
-### Release Checklist
-
-1. Update version in `package.json`
-2. Update `CHANGELOG.md`
-3. Create release branch: `release/v1.0.0`
-4. Final testing
-5. Merge to `main`
-6. Tag release: `git tag v1.0.0`
-7. Push tags: `git push --tags`
-8. GitHub Actions builds and deploys
-9. Publish release notes
-10. Merge back to `develop`
-
----
-
-## Questions?
-
-If you have questions about contributing, please:
-
-1. Check this guide
-2. Read the [documentation](docs/)
-3. Ask in [GitHub Discussions](https://github.com/yourusername/modern-ontology-editor/discussions)
-4. Join our [Discord/Slack](link)
-
----
-
-**Thank you for contributing to Modern Ontology Editor! 🎉**
+Thank you for contributing to ProtegeDesk!


### PR DESCRIPTION
## Description

Rewrites CONTRIBUTING.md to add a first-PR walkthrough and file map, as requested in #221.

### What changed

- **Welcome section** — a brief intro for new contributors pointing them to the walkthrough.
- **File map** — a directory-tree overview and a table explaining what goes in each key directory, matching the current repo structure.
- **Your First PR walkthrough** — step-by-step guide from forking through opening a pull request, with copy-paste-ready commands.
- **Code Style** — consolidated from the repo's actual config (`.prettierrc`, `eslint.config.mjs`, `tsconfig.json`): no semicolons, single quotes, 2-space indent, arrow-parens avoid, constants in `lib/constants.ts`.
- **Commit Messages** — Conventional Commits reference with branch prefix conventions.
- **Good First Issues** — links to 5 open `good-first-issue` items (#212, #218, #219, #220, #221).
- **Dev workflow** — documents `npm ci && npm test && npm run validate` as the canonical check.
- Removed stale references to `modern-ontology-editor`, `vitest`, `develop` branch, `src/` layout, and other content that did not match the actual repo.

### No changes to application code

This PR only modifies `CONTRIBUTING.md`.

Closes #221
